### PR TITLE
feat: add dockerfile for development environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,9 @@
+FROM node:20.10-alpine 
+
+WORKDIR /app
+
+COPY . .
+
+EXPOSE 5173
+
+ENTRYPOINT ["npm", "run", "dev"]

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   GithubLogo,
   InstagramLogo,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,8 @@ import mdx from "@mdx-js/rollup";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), mdx()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
 });


### PR DESCRIPTION
add a dockerfile to allow the execution of the projects in different environments without the installation of all libraries.
NOTE [THIS DOCKERFILE IS ONLY FOR DEVELOPMENT. A DIFFERENT ONE MUST BE CREATED FOR PRODUCTION]

Commands to run:

```
docker build -f Dockerfile.dev -t techknowledge-front-dev .
```
```
docker run -v $(pwd):/app -p 5173:5173 --name techknowledge-front-dev-container techknowledge-front-dev
```
